### PR TITLE
fix: ci setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         run: yarn
 
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
-      - run: npx nx affected -t lint test build --base=origin/main --head=${{ github.head_ref || github.ref_name }}
+      - run: npx nx affected -t lint test build --base=origin/main --head=origin/${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         run: yarn
 
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
-      - run: npx nx affected -t lint test build
+      - run: npx nx affected -t lint test build --base=origin/main --head=${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
The provided `nx` command works only from `main` branch. This change should get things working from other branches so that when running against a PR, it will pass as expected.